### PR TITLE
feat: Add Export for Claude Code feature to save chat context

### DIFF
--- a/src/ipc-messages.ts
+++ b/src/ipc-messages.ts
@@ -40,6 +40,7 @@ export const IpcMessages = {
   CHAT_DELETE_CHAT: "clippy_chat_delete_chat",
   CHAT_DELETE_ALL_CHATS: "clippy_chat_delete_all_chats",
   CHAT_NEW_CHAT: "clippy_chat_new_chat",
+  CHAT_EXPORT_FOR_CLAUDE: "clippy_chat_export_for_claude",
 
   // Clipboard
   CLIPBOARD_WRITE: "clippy_clipboard_write",

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,4 +1,5 @@
-import { clipboard, Data, ipcMain } from "electron";
+import { clipboard, Data, dialog, ipcMain } from "electron";
+import fs from "fs";
 import {
   toggleChatWindow,
   maximizeChatWindow,
@@ -95,9 +96,49 @@ export function setupIpcListeners() {
   ipcMain.handle(IpcMessages.CHAT_DELETE_ALL_CHATS, () =>
     getChatManager().deleteAllChats(),
   );
+  ipcMain.handle(
+    IpcMessages.CHAT_EXPORT_FOR_CLAUDE,
+    async (_, chatWithMessages: ChatWithMessages) => {
+      const result = await dialog.showSaveDialog({
+        title: "Export Chat for Claude Code",
+        defaultPath: "chat-context.md",
+        filters: [{ name: "Markdown", extensions: ["md"] }],
+      });
+
+      if (result.canceled || !result.filePath) {
+        return false;
+      }
+
+      const content = formatChatForClaude(chatWithMessages);
+      await fs.promises.writeFile(result.filePath, content, "utf8");
+      return true;
+    },
+  );
 
   // Clipboard
   ipcMain.handle(IpcMessages.CLIPBOARD_WRITE, (_, data: Data) =>
     clipboard.write(data, "clipboard"),
   );
+}
+
+function formatChatForClaude(chatWithMessages: ChatWithMessages): string {
+  const date = new Date(chatWithMessages.chat.createdAt).toLocaleString();
+  const lines: string[] = [
+    "# Clippy Chat Context",
+    "",
+    `> Exported from Clippy on ${date}`,
+    "",
+    "## Conversation",
+    "",
+  ];
+
+  for (const message of chatWithMessages.messages) {
+    if (!message.content) {
+      continue;
+    }
+    const speaker = message.sender === "user" ? "**User**" : "**Clippy**";
+    lines.push(`${speaker}: ${message.content}`, "");
+  }
+
+  return lines.join("\n");
 }

--- a/src/renderer/clippyApi.tsx
+++ b/src/renderer/clippyApi.tsx
@@ -52,6 +52,7 @@ export type ClippyApi = {
   deleteAllChats: () => Promise<void>;
   onNewChat: (callback: () => void) => void;
   offNewChat: () => void;
+  exportChatForClaude: (chatWithMessages: ChatWithMessages) => Promise<boolean>;
   // Clipboard
   clipboardWrite: (data: Data) => Promise<void>;
 };

--- a/src/renderer/components/BubbleWindow.tsx
+++ b/src/renderer/components/BubbleWindow.tsx
@@ -5,10 +5,14 @@ import { Chat } from "./Chat";
 import { Settings } from "./Settings";
 import { useBubbleView } from "../contexts/BubbleViewContext";
 import { Chats } from "./Chats";
+import { useChat } from "../contexts/ChatContext";
+import { MessageRecord } from "../../types/interfaces";
 
 export function Bubble() {
   const { currentView, setCurrentView } = useBubbleView();
+  const { messages, currentChatRecord } = useChat();
   const [isMaximized, setIsMaximized] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
 
   const containerStyle = {
     width: "calc(100% - 6px)",
@@ -57,6 +61,30 @@ export function Bubble() {
     }
   }, [setCurrentView, currentView]);
 
+  const handleExportForClaude = useCallback(async () => {
+    if (messages.length === 0) {
+      return;
+    }
+
+    setIsExporting(true);
+    try {
+      const messageRecords: MessageRecord[] = messages.map((m) => ({
+        id: m.id,
+        content: m.content,
+        sender: m.sender,
+        createdAt: m.createdAt,
+      }));
+      await clippyApi.exportChatForClaude({
+        chat: currentChatRecord,
+        messages: messageRecords,
+      });
+    } catch (error) {
+      console.error("Failed to export chat:", error);
+    } finally {
+      setIsExporting(false);
+    }
+  }, [messages, currentChatRecord]);
+
   return (
     <div className="bubble-container window" style={containerStyle}>
       <div className="app-drag title-bar">
@@ -82,6 +110,19 @@ export function Bubble() {
           >
             Settings
           </button>
+          {currentView === "chat" && messages.length > 0 && (
+            <button
+              style={{
+                marginRight: "8px",
+                paddingLeft: "8px",
+                paddingRight: "8px",
+              }}
+              onClick={handleExportForClaude}
+              disabled={isExporting}
+            >
+              Export for Claude
+            </button>
+          )}
           <button
             aria-label="Minimize"
             onClick={() => clippyApi.minimizeChatWindow()}

--- a/src/renderer/components/Chats.tsx
+++ b/src/renderer/components/Chats.tsx
@@ -19,6 +19,7 @@ export const Chats: React.FC<SettingsProps> = ({ onClose }) => {
     deleteAllChats,
   } = useChat();
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
   const [selectedChatIndex, setSelectedChatIndex] = useState<number | null>(
     null,
   );
@@ -95,6 +96,31 @@ export const Chats: React.FC<SettingsProps> = ({ onClose }) => {
     }
   };
 
+  const handleExportForClaude = async () => {
+    if (
+      selectedChatIndex === null ||
+      selectedChatIndex >= chatsWithPreview.length
+    ) {
+      return;
+    }
+
+    const chatId = chatsWithPreview[selectedChatIndex].id;
+    const chatWithMessages = await clippyApi.getChatWithMessages(chatId);
+
+    if (!chatWithMessages) {
+      return;
+    }
+
+    setIsExporting(true);
+    try {
+      await clippyApi.exportChatForClaude(chatWithMessages);
+    } catch (error) {
+      console.error("Failed to export chat:", error);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   const columns = [
     { key: "preview", header: "Preview" },
     { key: "lastUpdated", header: "Last Updated" },
@@ -125,6 +151,12 @@ export const Chats: React.FC<SettingsProps> = ({ onClose }) => {
             disabled={selectedChatIndex === null}
           >
             Restore Chat
+          </button>
+          <button
+            onClick={handleExportForClaude}
+            disabled={isExporting || selectedChatIndex === null}
+          >
+            Export for Claude
           </button>
           <button
             onClick={handleDeleteSelected}

--- a/src/renderer/preload.ts
+++ b/src/renderer/preload.ts
@@ -91,6 +91,8 @@ const clippyApi: ClippyApi = {
   offNewChat: () => {
     ipcRenderer.removeAllListeners(IpcMessages.CHAT_NEW_CHAT);
   },
+  exportChatForClaude: (chatWithMessages: ChatWithMessages) =>
+    ipcRenderer.invoke(IpcMessages.CHAT_EXPORT_FOR_CLAUDE, chatWithMessages),
 
   // App
   getVersions: () => ipcRenderer.invoke(IpcMessages.APP_GET_VERSIONS),


### PR DESCRIPTION
I decided to add this export for claude button. I thought of other LLM chat apps that offer something similar and since I am doing a lot of work with Claude and other LLMs, I thought this would be cool for Clippy. :)